### PR TITLE
move database interface from implementation of PostgreSQL to PostgreS…

### DIFF
--- a/databases/Postgres.cs
+++ b/databases/Postgres.cs
@@ -7,7 +7,7 @@ using KDG.Database.Interfaces;
 
 namespace KDG.Database;
 
-public class PostgreSQL : DML.PostgreSQL, IDatabase<NpgsqlConnection,NpgsqlTransaction> {
+public class PostgreSQL : DML.PostgreSQL {
     public string ConnectionString { get; set; }
     public PostgreSQL(string connectionString) {
         this.ConnectionString = connectionString;

--- a/dml/Postgres.cs
+++ b/dml/Postgres.cs
@@ -1,6 +1,8 @@
+using KDG.Database.Interfaces;
+using Npgsql;
 namespace KDG.Database.DML;
 
-public interface PostgreSQL {
+public interface PostgreSQL : IDatabase<NpgsqlConnection,NpgsqlTransaction> {
     public Task Insert<T>(Npgsql.NpgsqlTransaction transaction, InsertConfig<T> config);
     public Task Update<T>(Npgsql.NpgsqlTransaction transaction, UpdateConfig<T> config);
     public Task Upsert<T>(Npgsql.NpgsqlTransaction transaction, UpsertConfig<T> config);


### PR DESCRIPTION
This will allow dependency injection to automatically recognize PostgreSQL interface as an extension of IDatabase